### PR TITLE
Added /usr/bin as possible path for intel-undervolt

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -107,7 +107,7 @@ int main(void) {
         }
 
         /* check if intel-undervolt is available and accessible */
-        if (access("/bin/intel-undervolt", X_OK) < 0) {
+        if (access("/bin/intel-undervolt", X_OK) < 0 && access("/usr/bin/intel-undervolt", X_OK) < 0) {
                 fprintf(stdout, "%s", "\nerror accessing intel-undervolt. Does it exist in /bin/ ?\n");
                 exit(1);
         }


### PR DESCRIPTION
Hey, as intel-undervolt on ubuntu 19.04 with `sudo make install` installs it in /usr/bin I have decided to add that path to if condition :smiley: 